### PR TITLE
Add checkout action to tag_release

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,6 +40,7 @@ jobs:
     needs: [simple_deployment_pipeline]
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v3
       - name: Bump version and push tag
         if: ${{ github.event_name == 'push' }}
         uses: anothrNick/github-tag-action@1.67.0


### PR DESCRIPTION
Had a mysterious error in the pipeline claiming "not a git repository". Noticed that I only call "uses: actions/checkout@v3" in the simple_deployment_pipeline and tag_release is a different one. Maybe this was the cause of the error?